### PR TITLE
fix: Resolve ModuleNotFoundError in Docker environment

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,9 +45,15 @@ Follow these steps to set up and run the project locally.
     ```
 
 2.  **Create a Python virtual environment and activate it:**
+    - On macOS/Linux:
     ```bash
     python -m venv venv
-    source venv/bin/activate  # On Windows, use `venv\Scripts\activate`
+    source venv/bin/activate
+    ```
+    - On Windows:
+    ```bash
+    python -m venv venv
+    .\venv\Scripts\activate
     ```
 
 3.  **Install dependencies:**

--- a/README.ru.md
+++ b/README.ru.md
@@ -45,9 +45,15 @@
     ```
 
 2.  **Создайте и активируйте виртуальное окружение Python:**
+    - Для macOS/Linux:
     ```bash
     python -m venv venv
-    source venv/bin/activate  # Для Windows используйте `venv\Scripts\activate`
+    source venv/bin/activate
+    ```
+    - Для Windows:
+    ```bash
+    python -m venv venv
+    .\venv\Scripts\activate
     ```
 
 3.  **Установите зависимости:**

--- a/backend/main.py
+++ b/backend/main.py
@@ -1,8 +1,8 @@
 from fastapi import FastAPI, File, UploadFile, HTTPException, Body
 from fastapi.responses import StreamingResponse
 from fastapi.middleware.cors import CORSMiddleware
-from backend.main_pipeline import run_analysis_pipeline
-from backend.services import exporter
+from main_pipeline import run_analysis_pipeline
+from services import exporter
 import json
 
 app = FastAPI()

--- a/backend/main_pipeline.py
+++ b/backend/main_pipeline.py
@@ -3,11 +3,11 @@ import io
 from docx import Document
 
 # Import all our services
-from backend.services import protocol_parser
-from backend.services import drug_normalizer
-from backend.services import regulatory_checker
-from backend.services import pubmed_client
-from backend.services import ai_analyzer
+from services import protocol_parser
+from services import drug_normalizer
+from services import regulatory_checker
+from services import pubmed_client
+from services import ai_analyzer
 
 # Instantiate clients/services that need it
 pubmed = pubmed_client.PubMedClient()

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,5 +1,3 @@
-version: '3.8'
-
 services:
   redis:
     image: "redis:alpine"


### PR DESCRIPTION
This commit fixes the `ModuleNotFoundError: No module named 'backend'` that prevented the backend server from starting when run via `docker-compose`.

The root cause was that the Python import paths were incorrect for the execution context inside the Docker container. The imports were changed from absolute (e.g., `from backend.main_pipeline...`) to relative (e.g., `from main_pipeline...`) to match the file structure within the container's working directory.

This commit also includes minor improvements:
- Removed the obsolete `version` tag from `docker-compose.yml`.
- Improved the README files with clearer instructions for Windows users.