### PR TITLE
fix: Add missing httpx dependency for backend

### DIFF
--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -8,3 +8,4 @@ redis
 openpyxl
 lxml
 biopython
+httpx


### PR DESCRIPTION
This commit resolves a `ModuleNotFoundError: No module named 'httpx'` that occurred when starting the backend service in Docker.

The `httpx` library was used by the `drug_normalizer` and `regulatory_checker` services to make asynchronous API calls, but it was missing from the `requirements.txt` file.

This change adds `httpx` to the list of dependencies, ensuring it is installed during the Docker build process and allowing the backend server to start successfully.