### PR TITLE
fix: Add python-multipart dependency for file uploads

### DIFF
--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -9,3 +9,4 @@ openpyxl
 lxml
 biopython
 httpx
+python-multipart


### PR DESCRIPTION
This commit resolves a `RuntimeError: Form data requires "python-multipart" to be installed.` that occurred when starting the backend service.

The FastAPI `File()` dependency requires this library to parse multipart form data, but it was missing from `requirements.txt`.

This change adds `python-multipart` to the list of dependencies, allowing the backend server to start successfully.